### PR TITLE
Add picker options: filter, select_ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ return {
         execute = function(v)
           vim.fn.setreg('+', vim.inspect(v))
         end,
-        tags = { 'first' },
       },
       {
         name = 'Reload plugin',
@@ -74,7 +73,6 @@ return {
           package.loaded[name] = nil
           require(name).setup()
         end,
-        tags = { 'first', 'second' },
       },
     },
   },
@@ -98,12 +96,6 @@ return {
     --if set for string commands, it will populate the `:` command
     --@type bool
     require_input = false,
-    --When calling require('toolbox').show_picker(), you can pass it a tag
-    --Ex. require('toolbox').show_picker('first')
-    --Commands with the tag will be shown, if no tags are given when calling
-    --the function, it will show all commands available
-    --@type list 
-    tags = {},
     -- Higher weights will be placed higher in the list
     -- Lower weights will be placed lower, you can use negative
     -- numbers as well to put it at the end of the list
@@ -112,6 +104,73 @@ return {
   }
 }
 ```
+
+## Recipes
+
+<details><summary>Filter commands by tag</summary>
+
+### Configuration
+
+```lua
+opts = {
+  commands = {
+    { name = "Copy full path", execute = ":let @+ = expand('%:p')", tags = { "clipboard" } },
+    { name = "Copy filename", execute = ":let @+ = expand('%:t')", tags = { "clipboard" } },
+    { name = "Remove empty lines", execute = ":g/^$/d", tags = { "editor", "newline" } },
+  },
+}
+```
+
+### Usage
+
+```lua
+-- Show only clipboard commands
+local function filter(command)
+  return command.tags ~= nil and vim.tbl_contains(command.tags, "clipboard")
+end
+require("toolbox").show_picker(filter, { prompt = "Select clipboard command" })
+```
+
+</details>
+
+<details><summary>Filter commands by current filetype</summary>
+
+### Configuration
+
+```lua
+opts = {
+  commands = {
+    { name = "Copy full path", execute = ":let @+ = expand('%:p')" },
+    { name = "Format JSON with jq", execute = ":%!jq", filetype = "json" }
+    { name = "Format QML file", execute = ":qmlformat %", filetype = "qml" }
+  },
+}
+```
+
+### Usage
+
+```lua
+require("toolbox").show_picker(function(command)
+  return command.filetype == vim.bo.filetype
+end, { prompt = "Select " .. vim.bo.filetype .. " command" })
+```
+
+</details>
+
+<details><summary>Change command representation in the list</summary>
+
+### Usage
+
+```lua
+require("toolbox").show_picker(nil, {
+  format_item = function(command)
+    -- Display => and execute string after the name
+    return command.name .. " => " .. (type(command.execute) == "function" and "<function>" or command.execute)
+  end
+})
+```
+
+</details>
 
 ## TODOs
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ return {
     --if set for string commands, it will populate the `:` command
     --@type bool
     require_input = false,
+    --When calling require('toolbox').show_picker(), you can pass it a tag
+    --Ex. require('toolbox').show_picker('first')
+    --Commands with the tag will be shown, if no tags are given when calling
+    --the function, it will show all commands available
+    --@type list 
+    tags = {},
     -- Higher weights will be placed higher in the list
     -- Lower weights will be placed lower, you can use negative
     -- numbers as well to put it at the end of the list
@@ -105,37 +111,30 @@ return {
 }
 ```
 
-## Recipes
+## Usage
 
-<details><summary>Filter commands by tag</summary>
+Call `require('toolbox').show_picker()`, it accepts two optional arguments:
 
-### Configuration
+- tag
 
-```lua
-opts = {
-  commands = {
-    { name = "Copy full path", execute = ":let @+ = expand('%:p')", tags = { "clipboard" } },
-    { name = "Copy filename", execute = ":let @+ = expand('%:t')", tags = { "clipboard" } },
-    { name = "Remove empty lines", execute = ":g/^$/d", tags = { "editor", "newline" } },
-  },
-}
-```
+  - Toolbox will filter your commands by specified tags in each command
 
-### Usage
+- select_opts
 
-```lua
--- Show only clipboard commands
-local function filter(command)
-  return command.tags ~= nil and vim.tbl_contains(command.tags, "clipboard")
-end
-require("toolbox").show_picker(filter, { prompt = "Select clipboard command" })
-```
+  - This will be passed to vim.ui.select as the `opts` argument, see `:help vim.ui.select`
 
-</details>
+## Advanced
+
+For advanced users, toolbox contains a lower level function call `show_picker_custom`,
+that provides more control towards filtering (and sorting possibly in future).
+`show_picker_custom` does not require you to use tags for filtering, you can filter by
+anything you want. Advanced examples are below
+
+### Examples
 
 <details><summary>Filter commands by current filetype</summary>
 
-### Configuration
+#### Configuration
 
 ```lua
 opts = {
@@ -147,7 +146,7 @@ opts = {
 }
 ```
 
-### Usage
+#### Usage
 
 ```lua
 require("toolbox").show_picker(function(command)
@@ -159,7 +158,7 @@ end, { prompt = "Select " .. vim.bo.filetype .. " command" })
 
 <details><summary>Change command representation in the list</summary>
 
-### Usage
+#### Usage
 
 ```lua
 require("toolbox").show_picker(nil, {
@@ -171,7 +170,3 @@ require("toolbox").show_picker(nil, {
 ```
 
 </details>
-
-## TODOs
-
-1. Make it work in visual mode (Done)

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ opts = {
 #### Usage
 
 ```lua
-require("toolbox").show_picker({
+require("toolbox").show_picker_custom({
   filter = function(command)
     return command.filetype == vim.bo.filetype
   end

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ return {
         execute = function(v)
           vim.fn.setreg('+', vim.inspect(v))
         end,
+        tags = { 'first' },
       },
       {
         name = 'Reload plugin',
@@ -73,6 +74,7 @@ return {
           package.loaded[name] = nil
           require(name).setup()
         end,
+        tags = { 'first', 'second' },
       },
     },
   },

--- a/README.md
+++ b/README.md
@@ -149,9 +149,11 @@ opts = {
 #### Usage
 
 ```lua
-require("toolbox").show_picker(function(command)
-  return command.filetype == vim.bo.filetype
-end, { prompt = "Select " .. vim.bo.filetype .. " command" })
+require("toolbox").show_picker({
+  filter = function(command)
+    return command.filetype == vim.bo.filetype
+  end
+}, { prompt = "Select " .. vim.bo.filetype .. " command" })
 ```
 
 </details>

--- a/lua/toolbox/config.lua
+++ b/lua/toolbox/config.lua
@@ -1,0 +1,12 @@
+---@class Toolbox.Config
+---@field commands Toolbox.Command[]
+
+---@class Toolbox.Command
+---@field name string
+---@field execute string|function
+---@field require_input boolean
+---@field tags string[]?
+---@field weight number?
+
+---@class Toolbox.ShowPickerCustomOpts
+---@field filter fun(command: Toolbox.Command): boolean

--- a/lua/toolbox/init.lua
+++ b/lua/toolbox/init.lua
@@ -1,8 +1,34 @@
 local M = {}
+local H = {}
+
+H.filter_commands = function(filter)
+	if filter == nil then
+		return H.opts.commands
+	end
+
+	local filtered = {}
+	for _, command in ipairs(H.opts.commands) do
+		if filter(command) then
+			table.insert(filtered, command)
+		end
+	end
+	return filtered
+end
+
+H.find_command = function(name)
+	for _, command in ipairs(H.opts.commands) do
+		if command.name == name then
+			return command
+		end
+	end
+	return nil
+end
 
 function M.setup(opts)
-	opts = opts or {}
-	local commands = opts.commands or {}
+	opts = vim.tbl_extend("force", {
+		commands = {},
+	}, opts or {})
+
 	table.sort(opts.commands, function(a, b)
 		if a.weight ~= nil or b.weight ~= nil then
 			-- Higher weight should be shown first
@@ -12,29 +38,20 @@ function M.setup(opts)
 		return string.upper(a.name) < string.upper(b.name)
 	end)
 
-	M.commandMap = {}
-	M.tagToCommandList = {}
-	M.tagToCommandList[""] = {}
-	for _, command in ipairs(commands) do
-		M.commandMap[command.name] = {
-			execute = command.execute,
-			require_input = command.require_input or false,
-		}
-		table.insert(M.tagToCommandList[""], command.name)
-		for _, tag in ipairs(command.tags or {}) do
-			if M.tagToCommandList[tag] == nil then
-				M.tagToCommandList[tag] = {}
-			end
-			table.insert(M.tagToCommandList[tag], command.name)
-		end
-	end
+	H.opts = opts
 end
 
 function M.run(name)
-	local execute = M.commandMap[name].execute
-	if execute == nil or type(execute) ~= "function" then
-		error("Unknown or unexecutable command", 0)
+	local command = H.find_command(name)
+	if command == nil then
+		error("Command " .. name .. " is not found", 0)
 	end
+
+	local execute = command.execute
+	if execute == nil or type(execute) ~= "function" then
+		error("Command has unsupported function type", 0)
+	end
+
 	return {
 		withArgs = function(...)
 			local ok, res = pcall(execute, ...)
@@ -45,7 +62,7 @@ function M.run(name)
 	}
 end
 
-function M.show_picker(tag)
+function M.show_picker(filter, select_opts)
 	local mode = vim.api.nvim_get_mode()["mode"]
 	local isVisual = mode == "v" or mode == "V" or mode == "\22"
 	local startpos = vim.fn.getpos("v")
@@ -53,31 +70,21 @@ function M.show_picker(tag)
 	vim.api.nvim_buf_set_mark(startpos[1], "<", startpos[2], startpos[3], {})
 	vim.api.nvim_buf_set_mark(endpos[1], ">", endpos[2], endpos[3], {})
 
-	if tag == nil then
-		tag = ""
-	end
-	if M.tagToCommandList[tag] == nil then
-		error("Commands with the tag '" .. tag .. "' do not exist")
-		return
-	end
+	select_opts = vim.tbl_extend("force", {
+		prompt = "Toolbox",
+		format_item = function(command)
+			return command.name
+		end,
+	}, select_opts or {})
 
-	local promptTitle = "Toolbox"
-	if tag ~= "" then
-		promptTitle = promptTitle .. " <" .. tag .. ">"
-	end
-
-	vim.ui.select(M.tagToCommandList[tag], {
-		prompt = promptTitle,
-	}, function(choice)
-		if choice == nil then
+	vim.ui.select(H.filter_commands(filter), select_opts, function(command)
+		if command == nil then
 			return
+		elseif command.execute == nil then
+			error("Command " .. command.name .. " has no function to execute", 0)
 		end
 
-		local execute = M.commandMap[choice].execute
-		if execute == nil then
-			return
-		end
-
+		local execute = command.execute
 		if type(execute) == "function" then
 			local numParams = debug.getinfo(execute).nparams
 			if numParams > 0 then
@@ -89,7 +96,7 @@ function M.show_picker(tag)
 				end
 				vim.api.nvim_feedkeys(
 					vim.api.nvim_replace_termcodes(":lua require('toolbox').run(\"", true, false, true)
-						.. choice
+						.. command.name
 						.. vim.api.nvim_replace_termcodes(
 							'").withArgs()' .. hintText .. string.rep("<Left>", string.len(hintText) + 1),
 							true,
@@ -105,16 +112,13 @@ function M.show_picker(tag)
 			if not ok then
 				error(res, 0)
 			end
-			return
-		end
-
-		if type(execute) == "string" then
+		elseif type(execute) == "string" then
 			local cmdPrefix = ":"
 			if isVisual then
 				cmdPrefix = cmdPrefix .. "'<,'>"
 			end
 
-			if M.commandMap[choice].require_input then
+			if command.require_input then
 				vim.api.nvim_feedkeys(cmdPrefix .. execute, "m", false)
 				return
 			end
@@ -122,6 +126,8 @@ function M.show_picker(tag)
 			if not ok then
 				error(res, 0)
 			end
+		else
+			error("Command has unsupported function type", 0)
 		end
 	end)
 end

--- a/lua/toolbox/init.lua
+++ b/lua/toolbox/init.lua
@@ -1,13 +1,18 @@
 local M = {}
-local H = {}
 
-H.filter_commands = function(filter)
+---@type Toolbox.Config
+local options = {}
+
+---@param filter fun(command:Toolbox.Command)
+---@return Toolbox.Command[]
+local function filter_commands(filter)
 	if filter == nil then
-		return H.opts.commands
+		return options.commands
 	end
 
+	---@type Toolbox.Command[]
 	local filtered = {}
-	for _, command in ipairs(H.opts.commands) do
+	for _, command in ipairs(options.commands) do
 		if filter(command) then
 			table.insert(filtered, command)
 		end
@@ -15,8 +20,10 @@ H.filter_commands = function(filter)
 	return filtered
 end
 
-H.find_command = function(name)
-	for _, command in ipairs(H.opts.commands) do
+---@param name string
+---@return Toolbox.Command|nil
+local function find_command(name)
+	for _, command in ipairs(options.commands) do
 		if command.name == name then
 			return command
 		end
@@ -24,7 +31,9 @@ H.find_command = function(name)
 	return nil
 end
 
+--- @param opts Toolbox.Config
 function M.setup(opts)
+	--- @type Toolbox.Config
 	opts = vim.tbl_extend("force", {
 		commands = {},
 	}, opts or {})
@@ -38,18 +47,19 @@ function M.setup(opts)
 		return string.upper(a.name) < string.upper(b.name)
 	end)
 
-	H.opts = opts
+	options = opts
 end
 
+--- @param name string
 function M.run(name)
-	local command = H.find_command(name)
+	local command = find_command(name)
 	if command == nil then
 		error("Command " .. name .. " is not found", 0)
 	end
 
 	local execute = command.execute
 	if execute == nil or type(execute) ~= "function" then
-		error("Command has unsupported function type", 0)
+		error("Unknown or unexecutable command", 0)
 	end
 
 	return {
@@ -62,7 +72,46 @@ function M.run(name)
 	}
 end
 
-function M.show_picker(filter, select_opts)
+--- @param tag string|nil
+--- @param select_opts table Taken from vim.ui.select
+---     - prompt (string|nil)
+---               Text of the prompt. Defaults to `Select one of:`
+---     - format_item (function item -> text)
+---               Function to format an
+---               individual item from `items`. Defaults to `tostring`.
+---     - kind (string|nil)
+---               Arbitrary hint string indicating the item shape.
+---               Plugins reimplementing `vim.ui.select` may wish to
+---               use this to infer the structure or semantics of
+---               `items`, or the context in which select() was called.
+function M.show_picker(tag, select_opts)
+	if tag == nil or tag == "" then
+		M.show_picker_custom(nil, select_opts)
+		return
+	end
+
+	M.show_picker_custom({
+		filter = function(command)
+			return command.tags ~= nil and vim.tbl_contains(command.tags, tag)
+		end,
+	}, select_opts)
+end
+
+---@param opts Toolbox.ShowPickerCustomOpts?
+--- @param select_opts table Taken from vim.ui.select
+---     - prompt (string|nil)
+---               Text of the prompt. Defaults to `Select one of:`
+---     - format_item (function item -> text)
+---               Function to format an
+---               individual item from `items`. Defaults to `tostring`.
+---     - kind (string|nil)
+---               Arbitrary hint string indicating the item shape.
+---               Plugins reimplementing `vim.ui.select` may wish to
+---               use this to infer the structure or semantics of
+---               `items`, or the context in which select() was called.
+function M.show_picker_custom(opts, select_opts)
+	opts = opts or {}
+
 	local mode = vim.api.nvim_get_mode()["mode"]
 	local isVisual = mode == "v" or mode == "V" or mode == "\22"
 	local startpos = vim.fn.getpos("v")
@@ -77,59 +126,60 @@ function M.show_picker(filter, select_opts)
 		end,
 	}, select_opts or {})
 
-	vim.ui.select(H.filter_commands(filter), select_opts, function(command)
-		if command == nil then
-			return
-		elseif command.execute == nil then
-			error("Command " .. command.name .. " has no function to execute", 0)
-		end
+	vim.ui.select(
+		filter_commands(opts.filter),
+		select_opts,
+		---@param command Toolbox.Command
+		function(command)
+			if command == nil then
+				return
+			end
 
-		local execute = command.execute
-		if type(execute) == "function" then
-			local numParams = debug.getinfo(execute).nparams
-			if numParams > 0 then
-				local hintText = " -- " .. numParams
-				if numParams > 1 then
-					hintText = hintText .. " args required"
-				else
-					hintText = hintText .. " arg required"
+			local execute = command.execute
+			if type(execute) == "function" then
+				local numParams = debug.getinfo(execute).nparams
+				if numParams > 0 then
+					local hintText = " -- " .. numParams
+					if numParams > 1 then
+						hintText = hintText .. " args required"
+					else
+						hintText = hintText .. " arg required"
+					end
+					vim.api.nvim_feedkeys(
+						vim.api.nvim_replace_termcodes(":lua require('toolbox').run(\"", true, false, true)
+							.. command.name
+							.. vim.api.nvim_replace_termcodes(
+								'").withArgs()' .. hintText .. string.rep("<Left>", string.len(hintText) + 1),
+								true,
+								false,
+								true
+							),
+						"m",
+						false
+					)
+					return
 				end
-				vim.api.nvim_feedkeys(
-					vim.api.nvim_replace_termcodes(":lua require('toolbox').run(\"", true, false, true)
-						.. command.name
-						.. vim.api.nvim_replace_termcodes(
-							'").withArgs()' .. hintText .. string.rep("<Left>", string.len(hintText) + 1),
-							true,
-							false,
-							true
-						),
-					"m",
-					false
-				)
-				return
-			end
-			local ok, res = pcall(execute)
-			if not ok then
-				error(res, 0)
-			end
-		elseif type(execute) == "string" then
-			local cmdPrefix = ":"
-			if isVisual then
-				cmdPrefix = cmdPrefix .. "'<,'>"
-			end
+				local ok, res = pcall(execute)
+				if not ok then
+					error(res, 0)
+				end
+			elseif type(execute) == "string" then
+				local cmdPrefix = ":"
+				if isVisual then
+					cmdPrefix = cmdPrefix .. "'<,'>"
+				end
 
-			if command.require_input then
-				vim.api.nvim_feedkeys(cmdPrefix .. execute, "m", false)
-				return
+				if command.require_input then
+					vim.api.nvim_feedkeys(cmdPrefix .. execute, "m", false)
+					return
+				end
+				local ok, res = pcall(vim.cmd, cmdPrefix .. execute)
+				if not ok then
+					error(res, 0)
+				end
 			end
-			local ok, res = pcall(vim.cmd, cmdPrefix .. execute)
-			if not ok then
-				error(res, 0)
-			end
-		else
-			error("Command has unsupported function type", 0)
 		end
-	end)
+	)
 end
 
 return M

--- a/lua/toolbox/init.lua
+++ b/lua/toolbox/init.lua
@@ -63,7 +63,7 @@ function M.run(name)
 	end
 
 	return {
-		withArgs = function(...)
+		with_args = function(...)
 			local ok, res = pcall(execute, ...)
 			if not ok then
 				error(res, 0)
@@ -113,7 +113,7 @@ function M.show_picker_custom(opts, select_opts)
 	opts = opts or {}
 
 	local mode = vim.api.nvim_get_mode()["mode"]
-	local isVisual = mode == "v" or mode == "V" or mode == "\22"
+	local is_visual = mode == "v" or mode == "V" or mode == "\22"
 	local startpos = vim.fn.getpos("v")
 	local endpos = vim.fn.getpos(".")
 	vim.api.nvim_buf_set_mark(startpos[1], "<", startpos[2], startpos[3], {})
@@ -137,19 +137,19 @@ function M.show_picker_custom(opts, select_opts)
 
 			local execute = command.execute
 			if type(execute) == "function" then
-				local numParams = debug.getinfo(execute).nparams
-				if numParams > 0 then
-					local hintText = " -- " .. numParams
-					if numParams > 1 then
-						hintText = hintText .. " args required"
+				local num_params = debug.getinfo(execute).nparams
+				if num_params > 0 then
+					local hint_text = " -- " .. num_params
+					if num_params > 1 then
+						hint_text = hint_text .. " args required"
 					else
-						hintText = hintText .. " arg required"
+						hint_text = hint_text .. " arg required"
 					end
 					vim.api.nvim_feedkeys(
 						vim.api.nvim_replace_termcodes(":lua require('toolbox').run(\"", true, false, true)
 							.. command.name
 							.. vim.api.nvim_replace_termcodes(
-								'").withArgs()' .. hintText .. string.rep("<Left>", string.len(hintText) + 1),
+								'").with_args()' .. hint_text .. string.rep("<Left>", string.len(hint_text) + 1),
 								true,
 								false,
 								true
@@ -164,16 +164,16 @@ function M.show_picker_custom(opts, select_opts)
 					error(res, 0)
 				end
 			elseif type(execute) == "string" then
-				local cmdPrefix = ":"
-				if isVisual then
-					cmdPrefix = cmdPrefix .. "'<,'>"
+				local cmd_prefix = ":"
+				if is_visual then
+					cmd_prefix = cmd_prefix .. "'<,'>"
 				end
 
 				if command.require_input then
-					vim.api.nvim_feedkeys(cmdPrefix .. execute, "m", false)
+					vim.api.nvim_feedkeys(cmd_prefix .. execute, "m", false)
 					return
 				end
-				local ok, res = pcall(vim.cmd, cmdPrefix .. execute)
+				local ok, res = pcall(vim.cmd, cmd_prefix .. execute)
 				if not ok then
 					error(res, 0)
 				end

--- a/lua/toolbox/init.lua
+++ b/lua/toolbox/init.lua
@@ -31,9 +31,9 @@ local function find_command(name)
 	return nil
 end
 
---- @param opts Toolbox.Config
+---@param opts Toolbox.Config
 function M.setup(opts)
-	--- @type Toolbox.Config
+	---@type Toolbox.Config
 	opts = vim.tbl_extend("force", {
 		commands = {},
 	}, opts or {})
@@ -50,7 +50,7 @@ function M.setup(opts)
 	options = opts
 end
 
---- @param name string
+---@param name string
 function M.run(name)
 	local command = find_command(name)
 	if command == nil then
@@ -72,8 +72,8 @@ function M.run(name)
 	}
 end
 
---- @param tag string|nil
---- @param select_opts table Taken from vim.ui.select
+---@param tag string|nil
+---@param select_opts table Taken from vim.ui.select
 ---     - prompt (string|nil)
 ---               Text of the prompt. Defaults to `Select one of:`
 ---     - format_item (function item -> text)
@@ -98,7 +98,7 @@ function M.show_picker(tag, select_opts)
 end
 
 ---@param opts Toolbox.ShowPickerCustomOpts?
---- @param select_opts table Taken from vim.ui.select
+---@param select_opts table Taken from vim.ui.select
 ---     - prompt (string|nil)
 ---               Text of the prompt. Defaults to `Select one of:`
 ---     - format_item (function item -> text)


### PR DESCRIPTION
This PR introduces more flexibility to the command picker
- Specifying the filter function for the commands list
- Specifying `vim.ui.select` options
- Adding **Recipes** section to explain how to configure the toolbox for different needs

As a result, the property `tags` was removed because the new mechanism covers it. Please check the example with tags in **Recipes** section

This PR closes #14
Also, with the `vim.ui.select` options, it's easy to format the command name and append the description (#11)